### PR TITLE
Add NFT Sample

### DIFF
--- a/contracts/ERC721.sol
+++ b/contracts/ERC721.sol
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+
+/// @title ERC-721 Non-Fungible Token Standard
+/// @dev See https://eips.ethereum.org/EIPS/eip-721
+///  Note: the ERC-165 identifier for this interface is 0x80ac58cd.
+interface ERC721 /* is ERC165 */ {
+    /// @dev This emits when ownership of any NFT changes by any mechanism.
+    ///  This event emits when NFTs are created (`from` == 0) and destroyed
+    ///  (`to` == 0). Exception: during contract creation, any number of NFTs
+    ///  may be created and assigned without emitting Transfer. At the time of
+    ///  any transfer, the approved address for that NFT (if any) is reset to none.
+    event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
+
+    /// @dev This emits when the approved address for an NFT is changed or
+    ///  reaffirmed. The zero address indicates there is no approved address.
+    ///  When a Transfer event emits, this also indicates that the approved
+    ///  address for that NFT (if any) is reset to none.
+    event Approval(address indexed _owner, address indexed _approved, uint256 indexed _tokenId);
+
+    /// @dev This emits when an operator is enabled or disabled for an owner.
+    ///  The operator can manage all NFTs of the owner.
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    /// @notice Count all NFTs assigned to an owner
+    /// @dev NFTs assigned to the zero address are considered invalid, and this
+    ///  function throws for queries about the zero address.
+    /// @param _owner An address for whom to query the balance
+    /// @return The number of NFTs owned by `_owner`, possibly zero
+    function balanceOf(address _owner) external view returns (uint256);
+
+    /// @notice Find the owner of an NFT
+    /// @dev NFTs assigned to zero address are considered invalid, and queries
+    ///  about them do throw.
+    /// @param _tokenId The identifier for an NFT
+    /// @return The address of the owner of the NFT
+    function ownerOf(uint256 _tokenId) external view returns (address);
+
+    /// @notice Transfers the ownership of an NFT from one address to another address
+    /// @dev Throws unless `msg.sender` is the current owner, an authorized
+    ///  operator, or the approved address for this NFT. Throws if `_from` is
+    ///  not the current owner. Throws if `_to` is the zero address. Throws if
+    ///  `_tokenId` is not a valid NFT. When transfer is complete, this function
+    ///  checks if `_to` is a smart contract (code size > 0). If so, it calls
+    ///  `onERC721Received` on `_to` and throws if the return value is not
+    ///  `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    /// @param data Additional data with no specified format, sent in call to `_to`
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
+
+    /// @notice Transfers the ownership of an NFT from one address to another address
+    /// @dev This works identically to the other function with an extra data parameter,
+    ///  except this function just sets data to "".
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId) external payable;
+
+    /// @notice Transfer ownership of an NFT -- THE CALLER IS RESPONSIBLE
+    ///  TO CONFIRM THAT `_to` IS CAPABLE OF RECEIVING NFTS OR ELSE
+    ///  THEY MAY BE PERMANENTLY LOST
+    /// @dev Throws unless `msg.sender` is the current owner, an authorized
+    ///  operator, or the approved address for this NFT. Throws if `_from` is
+    ///  not the current owner. Throws if `_to` is the zero address. Throws if
+    ///  `_tokenId` is not a valid NFT.
+    /// @param _from The current owner of the NFT
+    /// @param _to The new owner
+    /// @param _tokenId The NFT to transfer
+    function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
+
+    /// @notice Change or reaffirm the approved address for an NFT
+    /// @dev The zero address indicates there is no approved address.
+    ///  Throws unless `msg.sender` is the current NFT owner, or an authorized
+    ///  operator of the current owner.
+    /// @param _approved The new approved NFT controller
+    /// @param _tokenId The NFT to approve
+    function approve(address _approved, uint256 _tokenId) external payable;
+
+    /// @notice Enable or disable approval for a third party ("operator") to manage
+    ///  all of `msg.sender`'s assets
+    /// @dev Emits the ApprovalForAll event. The contract MUST allow
+    ///  multiple operators per owner.
+    /// @param _operator Address to add to the set of authorized operators
+    /// @param _approved True if the operator is approved, false to revoke approval
+    function setApprovalForAll(address _operator, bool _approved) external;
+
+    /// @notice Get the approved address for a single NFT
+    /// @dev Throws if `_tokenId` is not a valid NFT.
+    /// @param _tokenId The NFT to find the approved address for
+    /// @return The approved address for this NFT, or the zero address if there is none
+    function getApproved(uint256 _tokenId) external view returns (address);
+
+    /// @notice Query if an address is an authorized operator for another address
+    /// @param _owner The address that owns the NFTs
+    /// @param _operator The address that acts on behalf of the owner
+    /// @return True if `_operator` is an approved operator for `_owner`, false otherwise
+    function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+}
+
+interface ERC165 {
+    /// @notice Query if a contract implements an interface
+    /// @param interfaceID The interface identifier, as specified in ERC-165
+    /// @dev Interface identification is specified in ERC-165. This function
+    ///  uses less than 30,000 gas.
+    /// @return `true` if the contract implements `interfaceID` and
+    ///  `interfaceID` is not 0xffffffff, `false` otherwise
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
+}

--- a/contracts/IERC20WithCheckpointing.sol
+++ b/contracts/IERC20WithCheckpointing.sol
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+
+contract IERC20WithCheckpointing is ERC20 {
+    function balanceOfAt(address _owner, uint256 _blockNumber) public view returns (uint256);
+    function totalSupplyAt(uint256 _blockNumber) public view returns (uint256);
+}

--- a/contracts/IERC20WithDecimals.sol
+++ b/contracts/IERC20WithDecimals.sol
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+
+contract IERC20WithDecimals is ERC20 {
+    function decimals() public view returns (uint8);
+}

--- a/contracts/IERC900History.sol
+++ b/contracts/IERC900History.sol
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+
+interface IERC900History {
+    function totalStakedForAt(address addr, uint256 blockNumber) external view returns (uint256);
+    function totalStakedAt(uint256 blockNumber) external view returns (uint256);
+
+    function supportsHistory() external pure returns (bool);
+}

--- a/contracts/NFTSample.sol
+++ b/contracts/NFTSample.sol
@@ -1,0 +1,278 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/apps/AragonApp.sol";
+import "@aragon/os/contracts/common/IForwarder.sol";
+import "@aragon/os/contracts/common/IsContract.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+import "./ERC721.sol";
+import "./IERC20WithCheckpointing.sol";
+import "./StaticInvoke.sol";
+
+
+/**
+ * @title NFTSample
+ * @notice Checkpoint wrapper around an ERC721 NFT that provide a "view-only" checkpointed ERC20 implementation for use with Voting apps.
+ * @dev Inspired by:
+ *   - MiniMe token
+ */
+contract NFTSample is IERC20WithCheckpointing, IForwarder, IsContract, AragonApp {
+    using SafeMath for uint256;
+    using StaticInvoke for address;
+
+    // TODO: just use keccak hashes
+    bytes32 public constant RESET_SAMPLE_ROLE = keccak256("RESET_SAMPLE_ROLE");
+
+    uint256 internal constant MAX_UINT128 = uint256(uint128(-1));
+
+    string private constant ERROR_NFT_NOT_CONTRACT = "NC_NFT_NOT_CONTRACT";
+    string private constant ERROR_GIVEN_NO_OWNERS = "NC_GIVEN_NO_OWNERS";
+    string private constant ERROR_CAN_NOT_FORWARD = "NC_CAN_NOT_FORWARD";
+    string private constant ERROR_UINT128_NUMBER_TOO_BIG = "NC_UINT128_NUMBER_TOO_BIG";
+    string private constant ERROR_NFT_BALANCE_REVERTED = "NC_NFT_BALANCE_REVERTED";
+
+    // Checkpoint struct for keeping track of token balances at particular block numbers
+    struct Checkpoint {
+        // `fromBlock` is the block number that the value was generated from
+        uint128 fromBlock;
+        // `value` is the amount of tokens at a specific block number
+        uint128 value;
+    }
+
+    struct Epoch {
+        // Checkpointed history of the sampled NFT balances
+        mapping (address => Checkpoint[]) balances;
+
+        // Checkpointed total supply of the sampled balances
+        Checkpoint[] totalSupplyHistory;
+    }
+
+    ERC721 public sampledNFT;
+    string public name;
+    string public symbol;
+
+    mapping (uint256 => Epoch) internal epochs;
+    uint256 public currentEpoch;
+
+    event UpdateHolder(address indexed entity, uint256 balance);
+
+    /**
+     * @notice Create a new checkpointed wrapper around an NFT
+     * @param _sampledNFT The sampled NFT
+     * @param _name The wrapped token's name
+     * @param _symbol The wrapped token's symbol
+     */
+    function initialize(ERC721 _sampledNFT, string _name, string _symbol) external onlyInit {
+        initialized();
+
+        require(isContract(_sampledNFT), ERROR_NFT_NOT_CONTRACT);
+
+        sampledNFT = _sampledNFT;
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function sample(address _owner) external onlyInit {
+        _sample(_owner);
+    }
+
+    function sampleMany(address[] _owners) external onlyInit {
+        uint256 ownersLength = _owners.length;
+        require(ownersLength > 0, ERROR_GIVEN_NO_OWNERS);
+
+        for (uint256 i = 0; i < ownersLength; i++) {
+            _sample(_owners[i]);
+        }
+    }
+
+    function resetSamples() external auth(RESET_SAMPLE_ROLE) {
+        ++currentEpoch;
+    }
+
+    // ERC20 fns - note that this token is a non-transferrable "view-only" implementation.
+    // Users should only be changing balances by re-sampling.
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function approve(address, uint256) public returns (bool) {
+        return false;
+    }
+
+    function transfer(address, uint256) public returns (bool) {
+        return false;
+    }
+
+    function transferFrom(address, address, uint256) public returns (bool) {
+        return false;
+    }
+
+    function allowance(address, address) public view returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address _owner) public view returns (uint256) {
+        return _balanceOfAt(_owner, getBlockNumber());
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _totalSupplyAt(getBlockNumber());
+    }
+
+    // Checkpointed fns
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function balanceOfAt(address _owner, uint256 _blockNumber) public view returns (uint256) {
+        return _balanceOfAt(_owner, _blockNumber);
+    }
+
+    function totalSupplyAt(uint256 _blockNumber) public view returns (uint256) {
+        return _totalSupplyAt(_blockNumber);
+    }
+
+    // Forwarding fns
+
+    /**
+    * @notice Tells whether the TokenWrapper app is a forwarder or not
+    * @dev IForwarder interface conformance
+    * @return Always true
+    */
+    function isForwarder() public pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @notice Execute desired action as a token holder
+     * @dev IForwarder interface conformance. Forwards any token holder action.
+     * @param _evmScript Script being executed
+     */
+    function forward(bytes _evmScript) public {
+        require(canForward(msg.sender, _evmScript), ERROR_CAN_NOT_FORWARD);
+        bytes memory input = new bytes(0);
+
+        // No blacklist needed as this contract should not hold any power over the sampled NFT
+        runScript(_evmScript, input, new address[](0));
+    }
+
+    /**
+    * @notice Tells whether `_sender` can forward actions or not
+    * @dev IForwarder interface conformance
+    * @param _sender Address of the account intending to forward an action
+    * @return True if the given address can forward actions, false otherwise
+    */
+    function canForward(address _sender, bytes) public view returns (bool) {
+        return hasInitialized() && balanceOf(_sender) > 0;
+    }
+
+    // Internal fns
+
+    function _sample(address _owner) internal {
+        Epoch storage epoch = epochs[currentEpoch];
+
+        // We diff against the previous known balance so that we only incrementally commit changes
+        // to total supply and avoid spurious checkpointing
+        uint256 currentBalance = _staticBalanceOf(_owner);
+        uint256 previousKnownBalance = balanceOf(_owner);
+        uint256 currentTotalSupply = totalSupply();
+
+        Checkpoint[] storage totalSupplyHistory = epoch.totalSupplyHistory;
+        uint256 diff;
+        uint256 newTotalSupply;
+        if (previousKnownBalance < currentBalance) {
+            diff = currentBalance.sub(previousKnownBalance);
+            newTotalSupply = currentTotalSupply.add(diff);
+        } else if (previousKnownBalance > currentBalance) {
+            diff = previousKnownBalance.sub(currentBalance);
+            newTotalSupply = currentTotalSupply.sub(diff);
+        }
+
+        // Commit updates, if there was actually a difference
+        if (diff != 0) {
+            _updateValueAtNow(epoch.balances[_owner], _toUint128(currentBalance));
+            _updateValueAtNow(totalSupplyHistory, _toUint128(newTotalSupply));
+        }
+    }
+
+    function _updateValueAtNow(Checkpoint[] storage _checkpoints, uint128 _value) internal {
+        uint256 checkpointsLength = _checkpoints.length;
+
+        if ((checkpointsLength == 0) || (_checkpoints[checkpointsLength - 1].fromBlock < getBlockNumber())) {
+            Checkpoint storage newCheckPoint = _checkpoints[checkpointsLength + 1];
+            newCheckPoint.fromBlock = uint128(getBlockNumber64());
+            newCheckPoint.value = _value;
+        } else {
+            Checkpoint storage oldCheckPoint = _checkpoints[checkpointsLength - 1];
+            oldCheckPoint.value = _value;
+        }
+    }
+
+    function _balanceOfAt(address _owner, uint256 _blockNumber) internal view returns (uint256) {
+        Epoch storage epoch = epochs[currentEpoch];
+        _getCheckpointedValueAt(epoch.balances[_owner], _blockNumber);
+    }
+
+    function _totalSupplyAt(uint256 _blockNumber) internal view returns (uint256) {
+        Epoch storage epoch = epochs[currentEpoch];
+        _getCheckpointedValueAt(epoch.totalSupplyHistory, _blockNumber);
+    }
+
+    function _getCheckpointedValueAt(Checkpoint[] storage _checkpoints, uint256 _blockNumber) internal view returns (uint256) {
+        uint256 checkpointsLength = _checkpoints.length;
+
+        // Short circuit if there's no checkpoints yet
+        // Note that this also lets us avoid using SafeMath later on, as we've established that
+        // there must be at least one checkpoint
+        if (checkpointsLength == 0) {
+            return 0;
+        }
+
+        // Check last checkpoint
+        uint256 lastCheckpointIndex = checkpointsLength - 1;
+        Checkpoint storage lastCheckpoint = _checkpoints[lastCheckpointIndex];
+        if (_blockNumber >= lastCheckpoint.fromBlock) {
+            return uint256(lastCheckpoint.value);
+        }
+
+        // Check first checkpoint (if not already checked with the above check on last)
+        if (checkpointsLength == 1 || _blockNumber < _checkpoints[0].fromBlock) {
+            return 0;
+        }
+
+        // Binary search through checkpoints
+        uint256 min = 0;
+        uint256 max = checkpointsLength - 1;
+        while (max > min) {
+            uint256 mid = (max + min + 1) / 2;
+            if (_checkpoints[mid].fromBlock <= _blockNumber) {
+                min = mid;
+            } else {
+                // Note that we don't need SafeMath here because mid must always be greater than 0
+                // from the while condition
+                max = mid - 1;
+            }
+        }
+        return uint256(_checkpoints[min].value);
+    }
+
+    function _toUint128(uint256 _a) internal pure returns (uint128) {
+        require(_a <= MAX_UINT128, ERROR_UINT128_NUMBER_TOO_BIG);
+        return uint128(_a);
+    }
+
+    // Private fns
+
+    function _staticBalanceOf(address _owner) internal view returns (uint256) {
+        bytes memory balanceOfCallData = abi.encodeWithSelector(
+            sampledNFT.balanceOf.selector,
+            _owner
+        );
+
+        (bool success, uint256 tokenBalance) = address(sampledNFT).staticInvoke(balanceOfCallData);
+        require(success, ERROR_NFT_BALANCE_REVERTED);
+
+        return tokenBalance;
+    }
+}

--- a/contracts/StaticInvoke.sol
+++ b/contracts/StaticInvoke.sol
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+
+library StaticInvoke {
+    function staticInvoke(address _addr, bytes memory _calldata)
+        internal
+        view
+        returns (bool, uint256)
+    {
+        bool success;
+        uint256 ret;
+        assembly {
+            let ptr := mload(0x40)    // free memory pointer
+
+            success := staticcall(
+                gas,                  // forward all gas
+                _addr,                // address
+                add(_calldata, 0x20), // calldata start
+                mload(_calldata),     // calldata length
+                ptr,                  // write output over free memory
+                0x20                  // uint256 return
+            )
+
+            if gt(success, 0) {
+                ret := mload(ptr)
+            }
+        }
+        return (success, ret);
+    }
+}

--- a/contracts/TokenWrapper.sol
+++ b/contracts/TokenWrapper.sol
@@ -6,113 +6,172 @@ pragma solidity 0.4.24;
 
 import "@aragon/os/contracts/apps/AragonApp.sol";
 import "@aragon/os/contracts/common/IForwarder.sol";
-import "@aragon/os/contracts/common/SafeERC20.sol";
+import "@aragon/os/contracts/common/IsContract.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
 import "@aragon/os/contracts/lib/token/ERC20.sol";
-import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
-import "@aragon/apps-shared-minime/contracts/ITokenController.sol";
+
+import "./IERC20WithCheckpointing.sol";
+import "./IERC20WithDecimals.sol";
 
 
 /**
  * @title TokenWrapper
- * @dev Based on https://github.com/MyBitFoundation/MyBit-DAO.tech/blob/master/apps/MyTokens/contracts/MyTokens.sol
+ * @notice Wrapper around a normal ERC20 token that provides a "view-only" checkpointed ERC20 implementation for use with Voting apps.
+ * @dev Inspired by:
+ *   - MiniMe token
+ *   - https://github.com/MyBitFoundation/MyBit-DAO.tech/blob/master/apps/MyTokens/contracts/MyTokens.sol
  */
-contract TokenWrapper is ITokenController, IForwarder, AragonApp {
+contract TokenWrapper is IERC20WithCheckpointing, IForwarder, IsContract, AragonApp {
+    using SafeMath for uint256;
     using SafeERC20 for ERC20;
 
-    string private constant ERROR_CAN_NOT_FORWARD = "TW_CAN_NOT_FORWARD";
-    string private constant ERROR_CALLER_NOT_TOKEN = "TW_CALLER_NOT_TOKEN";
+    uint256 internal constant MAX_UINT128 = uint256(uint128(-1));
+
+    string private constant ERROR_TOKEN_NOT_CONTRACT = "TW_TOKEN_NOT_CONTRACT";
     string private constant ERROR_DEPOSIT_AMOUNT_ZERO = "TW_DEPOSIT_AMOUNT_ZERO";
+    string private constant ERROR_TOKEN_TRANSFER_FROM_FAILED = "TW_TOKEN_TRANSFER_FROM_FAILED";
     string private constant ERROR_WITHDRAW_AMOUNT_ZERO = "TW_WITHDRAW_AMOUNT_ZERO";
     string private constant ERROR_INVALID_WITHDRAW_AMOUNT = "TW_INVALID_WITHDRAW_AMOUNT";
-    string private constant ERROR_INVALID_TOKEN_CONTROLLER = "TW_INVALID_TOKEN_CONTROLLER";
-    string private constant ERROR_TOKEN_BURN_FAILED = "TW_TOKEN_BURN_FAILED";
-    string private constant ERROR_TOKEN_MINT_FAILED = "TW_TOKEN_MINT_FAILED";
-    string private constant ERROR_ERC20_TRANSFER_FAILED = "TW_ERC20_TRANSFER_FAILED";
-    string private constant ERROR_ERC20_TRANSFER_FROM_FAILED = "TW_ERC20_TRANSFER_FROM_FAILED";
+    string private constant ERROR_TOKEN_TRANSFER_FAILED = "TW_TOKEN_TRANSFER_FAILED";
+    string private constant ERROR_CAN_NOT_FORWARD = "TW_CAN_NOT_FORWARD";
+    string private constant ERROR_UINT128_NUMBER_TOO_BIG = "TW_UINT128_NUMBER_TOO_BIG";
 
-    ERC20 public erc20;
-    MiniMeToken public token;
+    // Checkpoint struct for keeping track of token balances at particular block numbers
+    struct Checkpoint {
+        // `fromBlock` is the block number that the value was generated from
+        uint128 fromBlock;
+        // `value` is the amount of tokens at a specific block number
+        uint128 value;
+    }
+
+    ERC20 public outsideToken;
+    string public name;
+    string public symbol;
+
+    // Checkpointed balances of the wrapped token
+    mapping (address => Checkpoint[]) internal balances;
+
+    // Checkpointed total supply of the wrapped token
+    Checkpoint[] internal totalSupplyHistory;
 
     event Deposit(address indexed entity, uint256 amount);
     event Withdrawal(address indexed entity, uint256 amount);
 
-    modifier onlyToken() {
-        require(msg.sender == address(token), ERROR_CALLER_NOT_TOKEN);
-        _;
-    }
-
     /**
-     * @notice Initialize a new MiniMe token that will be convertible from an ERC20 token
-     * @param _token The MiniMeToken controlled by this app
-     * @param _erc20 The ERC20 token that is deposited in order to receive MiniMe tokens
+     * @notice Create a new checkpointed wrapped token that will be convertible from a normal ERC20 token
+     * @param _outsideToken The ERC20 token that is deposited
+     * @param _name The wrapped token's name
+     * @param _symbol The wrapped token's symbol
      */
-    function initialize(MiniMeToken _token, ERC20 _erc20) external {
+    function initialize(ERC20 _outsideToken, string _name, string _symbol) external onlyInit {
         initialized();
-        require(_token.controller() == address(this), ERROR_INVALID_TOKEN_CONTROLLER);
 
-        token = _token;
-        erc20 = _erc20;
-        token.enableTransfers(false);
+        require(isContract(_outsideToken), ERROR_TOKEN_NOT_CONTRACT);
+
+        outsideToken = _outsideToken;
+        name = _name;
+        symbol = _symbol;
     }
 
     /**
-     * @notice Wrap `@tokenAmount(self.erc20(): address, _amount)`
+     * @notice Wrap `@tokenAmount(self.outsideToken(): address, _amount)`
+     * @param _amount Amount to wrap
      */
-    function deposit(uint256 _amount) external {
+    function deposit(uint256 _amount) external isInitialized {
         require(_amount > 0, ERROR_DEPOSIT_AMOUNT_ZERO);
 
-        // Fetch erc20 tokens and mint minime tokens
-        require(erc20.safeTransferFrom(msg.sender, address(this), _amount), ERROR_ERC20_TRANSFER_FROM_FAILED);
-        require(token.generateTokens(msg.sender, _amount), ERROR_TOKEN_MINT_FAILED);
+        // Increase our wrapped token accounting
+        uint256 currentBalance = balanceOf(msg.sender);
+        uint128 newBalance = _toUint128(currentBalance.add(_amount));
+
+        uint256 currentTotalSupply = totalSupply();
+        uint128 newTotalSupply = _toUint128(currentTotalSupply.add(_amount));
+
+        _updateValueAtNow(balances[msg.sender], newBalance);
+        _updateValueAtNow(totalSupplyHistory, newTotalSupply);
+
+        // Then fetch the outside ERC20 tokens
+        require(outsideToken.safeTransferFrom(msg.sender, address(this), _amount), ERROR_TOKEN_TRANSFER_FROM_FAILED);
 
         emit Deposit(msg.sender, _amount);
     }
 
     /**
-     * @notice Unwrap `@tokenAmount(self.erc20(): address, _amount)`
+     * @notice Unwrap `@tokenAmount(self.outsideToken(): address, _amount)`
+     * @param _amount Amount to unwrap
      */
-    function withdraw(uint256 _amount) external {
+    function withdraw(uint256 _amount) external isInitialized {
         require(_amount > 0, ERROR_WITHDRAW_AMOUNT_ZERO);
-        require(_amount <= ERC20(token).staticBalanceOf(msg.sender), ERROR_INVALID_WITHDRAW_AMOUNT);
 
-        // Burn minime tokens and return erc20 tokens
-        require(token.destroyTokens(msg.sender, _amount), ERROR_TOKEN_BURN_FAILED);
-        require(erc20.safeTransfer(msg.sender, _amount), ERROR_ERC20_TRANSFER_FAILED);
+        uint256 currentBalance = balanceOf(msg.sender);
+        require(_amount <= currentBalance, ERROR_INVALID_WITHDRAW_AMOUNT);
+
+        // Decrease our wrapped token accounting
+        uint128 newBalance = _toUint128(currentBalance.sub(_amount));
+
+        uint256 currentTotalSupply = totalSupply();
+        uint128 newTotalSupply = _toUint128(currentTotalSupply.sub(_amount));
+
+        _updateValueAtNow(balances[msg.sender], newBalance);
+        _updateValueAtNow(totalSupplyHistory, newTotalSupply);
+
+        // Then return ERC20 tokens
+        require(outsideToken.safeTransfer(msg.sender, _amount), ERROR_TOKEN_TRANSFER_FAILED);
 
         emit Withdrawal(msg.sender, _amount);
     }
 
-    // ITokenController fns
-    // `onTransfer()`, `onApprove()`, and `proxyPayment()` are callbacks from the MiniMe token
-    // contract and are only meant to be called through the managed MiniMe token that gets assigned
-    // during initialization.
+    // ERC20 fns - note that this token is a non-transferrable "view-only" implementation.
+    // Users should only be changing balances by depositing and withdrawing tokens.
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
 
-    /*
-    * @dev Notifies the controller about a token transfer allowing the controller to react if desired
-    * @return Always false to deny transfers
-    */
-    function onTransfer(address, address, uint256) external onlyToken returns (bool) {
+    function approve(address, uint256) public returns (bool) {
         return false;
     }
 
-    /**
-     * @dev Notifies the controller about an approval allowing the controller to react if desired
-     * @return Always false to deny approvals
-     */
-    function onApprove(address, address, uint256) external onlyToken returns (bool) {
+    function transfer(address, uint256) public returns (bool) {
         return false;
     }
 
-    /**
-     * @dev Notifies the controller when the token contract receives ETH allowing the controller to react if desired
-     * @return Always false to deny sent ETH
-     */
-    function proxyPayment(address) external payable onlyToken returns (bool) {
+    function transferFrom(address, address, uint256) public returns (bool) {
         return false;
+    }
+
+    function allowance(address, address) public view returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address _owner) public view returns (uint256) {
+        return _balanceOfAt(_owner, getBlockNumber());
+    }
+
+    function decimals() public view returns (uint8) {
+        // Decimals is optional; proxy to outside token
+        return IERC20WithDecimals(outsideToken).decimals();
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return _totalSupplyAt(getBlockNumber());
+    }
+
+    // Checkpointed fns
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function balanceOfAt(address _owner, uint256 _blockNumber) public view returns (uint256) {
+        return _balanceOfAt(_owner, _blockNumber);
+    }
+
+    function totalSupplyAt(uint256 _blockNumber) public view returns (uint256) {
+        return _totalSupplyAt(_blockNumber);
     }
 
     // Forwarding fns
 
+    /**
+    * @notice Tells whether the TokenWrapper app is a forwarder or not
+    * @dev IForwarder interface conformance
+    * @return Always true
+    */
     function isForwarder() public pure returns (bool) {
         return true;
     }
@@ -126,17 +185,87 @@ contract TokenWrapper is ITokenController, IForwarder, AragonApp {
         require(canForward(msg.sender, _evmScript), ERROR_CAN_NOT_FORWARD);
         bytes memory input = new bytes(0);
 
-        // Add both known tokens to the blacklist to disallow a token holder from interacting with
-        // either token on this contract's behalf.
-        // Note that this contract is the controller of at least the attached MiniMe token.
-        address[] memory blacklist = new address[](2);
-        blacklist[0] = address(token);
-        blacklist[1] = address(erc20);
+        // Add the wrapped token to the blacklist to disallow a token holder from interacting with
+        // the token on this contract's behalf (e.g. maliciously causing a transfer).
+        address[] memory blacklist = new address[](1);
+        blacklist[0] = address(outsideToken);
 
         runScript(_evmScript, input, blacklist);
     }
 
+    /**
+    * @notice Tells whether `_sender` can forward actions or not
+    * @dev IForwarder interface conformance
+    * @param _sender Address of the account intending to forward an action
+    * @return True if the given address can forward actions, false otherwise
+    */
     function canForward(address _sender, bytes) public view returns (bool) {
-        return hasInitialized() && ERC20(token).staticBalanceOf(_sender) > 0;
+        return hasInitialized() && balanceOf(_sender) > 0;
+    }
+
+    // Internal fns
+
+    function _updateValueAtNow(Checkpoint[] storage _checkpoints, uint128 _value) internal {
+        uint256 checkpointsLength = _checkpoints.length;
+
+        if ((checkpointsLength == 0) || (_checkpoints[checkpointsLength - 1].fromBlock < getBlockNumber())) {
+            Checkpoint storage newCheckPoint = _checkpoints[checkpointsLength + 1];
+            newCheckPoint.fromBlock = uint128(getBlockNumber64());
+            newCheckPoint.value = _value;
+        } else {
+            Checkpoint storage oldCheckPoint = _checkpoints[checkpointsLength - 1];
+            oldCheckPoint.value = _value;
+        }
+    }
+
+    function _balanceOfAt(address _owner, uint256 _blockNumber) internal view returns (uint256) {
+        _getCheckpointedValueAt(balances[_owner], _blockNumber);
+    }
+
+    function _totalSupplyAt(uint256 _blockNumber) internal view returns (uint256) {
+        _getCheckpointedValueAt(totalSupplyHistory, _blockNumber);
+    }
+
+    function _getCheckpointedValueAt(Checkpoint[] storage _checkpoints, uint256 _blockNumber) internal view returns (uint256) {
+        uint256 checkpointsLength = _checkpoints.length;
+
+        // Short circuit if there's no checkpoints yet
+        // Note that this also lets us avoid using SafeMath later on, as we've established that
+        // there must be at least one checkpoint
+        if (checkpointsLength == 0) {
+            return 0;
+        }
+
+        // Check last checkpoint
+        uint256 lastCheckpointIndex = checkpointsLength - 1;
+        Checkpoint storage lastCheckpoint = _checkpoints[lastCheckpointIndex];
+        if (_blockNumber >= lastCheckpoint.fromBlock) {
+            return uint256(lastCheckpoint.value);
+        }
+
+        // Check first checkpoint (if not already checked with the above check on last)
+        if (checkpointsLength == 1 || _blockNumber < _checkpoints[0].fromBlock) {
+            return 0;
+        }
+
+        // Binary search through checkpoints
+        uint256 min = 0;
+        uint256 max = checkpointsLength - 1;
+        while (max > min) {
+            uint256 mid = (max + min + 1) / 2;
+            if (_checkpoints[mid].fromBlock <= _blockNumber) {
+                min = mid;
+            } else {
+                // Note that we don't need SafeMath here because mid must always be greater than 0
+                // from the while condition
+                max = mid - 1;
+            }
+        }
+        return uint256(_checkpoints[min].value);
+    }
+
+    function _toUint128(uint256 _a) internal pure returns (uint128) {
+        require(_a <= MAX_UINT128, ERROR_UINT128_NUMBER_TOO_BIG);
+        return uint128(_a);
     }
 }

--- a/contracts/VotingAggregator.sol
+++ b/contracts/VotingAggregator.sol
@@ -1,0 +1,406 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/apps/AragonApp.sol";
+import "@aragon/os/contracts/common/IForwarder.sol";
+import "@aragon/os/contracts/common/IsContract.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+import "./IERC20WithCheckpointing.sol";
+import "./IERC900History.sol";
+import "./StaticInvoke.sol";
+
+
+/**
+ * @title VotingAggregator
+ * @notice Voting power aggregator across many sources that provides a "view-only" checkpointed ERC20 implementation
+ */
+contract VotingAggregator is IERC20WithCheckpointing, IForwarder, IsContract, AragonApp {
+    using SafeMath for uint256;
+    using StaticInvoke for address;
+
+    // TODO: just use keccak hashes
+    bytes32 public constant ADD_POWER_SOURCE_ROLE = keccak256("ADD_POWER_SOURCE_ROLE");
+    bytes32 public constant MANAGE_POWER_SOURCE_ROLE = keccak256("MANAGE_POWER_SOURCE_ROLE");
+    bytes32 public constant MANAGE_WEIGHTS_ROLE = keccak256("MANAGE_WEIGHTS_ROLE");
+
+    uint128 internal constant MAX_UINT128 = uint128(-1);
+
+    string private constant ERROR_NO_POWER_SOURCE = "VA_NO_POWER_SOURCE";
+    string private constant ERROR_POWER_SOURCE_NOT_CONTRACT = "VA_POWER_SOURCE_NOT_CONTRACT";
+    string private constant ERROR_SOURCE_NOT_ENABLED = "VA_POWER_SOURCE_NOT_ENABLED";
+    string private constant ERROR_SOURCE_NOT_DISABLED = "VA_POWER_SOURCE_NOT_DISABLED";
+    string private constant ERROR_CAN_NOT_FORWARD = "VA_CAN_NOT_FORWARD";
+    string private constant ERROR_SOURCE_CALL_FAILED = "VA_SOURCE_CALL_FAILED";
+    string private constant ERROR_INVALID_SOURCE_ACTIVE_HISTORY = "VA_INVALID_SOURCE_ACTIVE_HISTORY";
+    string private constant ERROR_INVALID_CALL_OR_SELECTOR = "VA_INVALID_CALL_OR_SELECTOR";
+
+    enum PowerSourceType {
+        ERC20WithCheckpointing,
+        ERC900
+    }
+
+    enum CallType {
+        BalanceOfAt,
+        TotalSupplyAt
+    }
+
+    // Range of [enabledFromBlock, disabledOnBlock)
+    struct ActiveRange {
+        uint128 enabledFromBlock;
+        uint128 disabledOnBlock;
+    }
+
+    struct PowerSource {
+        address addr;
+        PowerSourceType sourceType;
+        uint256 weight;
+        ActiveRange[] activationHistory;
+    }
+
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+
+    mapping (uint256 => PowerSource) internal powerSources;
+    uint256 public powerSourcesLength;
+
+    event AddPowerSource(uint256 indexed sourceId, address indexed sourceAddress, PowerSourceType sourceType, uint256 weight);
+    event ChangePowerSourceWeight(uint256 indexed sourceId, uint256 newWeight);
+    event DisablePowerSource(uint256 indexed sourceId);
+    event EnablePowerSource(uint256 indexed sourceId);
+
+    modifier sourceExists(uint256 _sourceId) {
+        require(_sourceId <= powerSourcesLength, ERROR_NO_POWER_SOURCE);
+        _;
+    }
+
+    /**
+     * @notice Create a new voting power aggregator
+     * @param _name The aggregator's display name
+     * @param _symbol The aggregator's display symbol
+     * @param _decimals The aggregator's display decimal units
+     */
+    function initialize(string _name, string _symbol, uint8 _decimals) external onlyInit {
+        initialized();
+
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+    }
+
+    /**
+     * @notice Add a new power source (`_sourceAddr`) with `_weight` weight
+     * @param _sourceAddr Address of the power source
+     * @param _sourceType Interface type of the power source
+     * @param _weight Weight to assign to the source
+     * @return Id of added power source
+     */
+    function addPowerSource(address _sourceAddr, PowerSourceType _sourceType, uint256 _weight)
+        external
+        authP(ADD_POWER_SOURCE_ROLE, arr(_sourceAddr, _weight))
+        returns (uint256)
+    {
+        require(isContract(_sourceAddr), ERROR_POWER_SOURCE_NOT_CONTRACT);
+
+        uint256 newSourceId = powerSourcesLength++;
+
+        PowerSource storage source = powerSources[newSourceId];
+        source.addr = _sourceAddr;
+        source.sourceType = _sourceType;
+        source.weight = _weight;
+
+        // Start activation history with [current block, max block)
+        source.activationHistory.push(
+            ActiveRange(
+                uint128(getBlockNumber64()), // enabled block
+                MAX_UINT128                  // disabled block
+            )
+        );
+
+        emit AddPowerSource(newSourceId, _sourceAddr, _sourceType, _weight);
+    }
+
+    /**
+     * @notice Change weight of power source #`_sourceId` to `_weight`
+     * @param _sourceId Power source id
+     * @param _weight New weight to assign
+     */
+    function changeSourceWeight(uint256 _sourceId, uint256 _weight)
+        external
+        authP(MANAGE_WEIGHTS_ROLE, arr(_weight, powerSources[_sourceId].weight))
+        sourceExists(_sourceId)
+    {
+        powerSources[_sourceId].weight = _weight;
+        emit ChangePowerSourceWeight(_sourceId, _weight);
+    }
+
+    /**
+     * @notice Disable power source #`_sourceId`
+     * @param _sourceId Power source id
+     */
+    function disableSource(uint256 _sourceId)
+        external
+        authP(MANAGE_POWER_SOURCE_ROLE, arr(uint256(0)))
+        sourceExists(_sourceId)
+    {
+        PowerSource storage source = powerSources[_sourceId];
+        require(_sourceEnabledAt(source, getBlockNumber()), ERROR_SOURCE_NOT_ENABLED);
+
+        ActiveRange[] storage activationHistory = source.activationHistory;
+        ActiveRange storage currentActiveRange = activationHistory[activationHistory.length];
+        currentActiveRange.disabledOnBlock = uint128(getBlockNumber64());
+
+        emit DisablePowerSource(_sourceId);
+    }
+
+    /**
+     * @notice Enable power source #`_sourceId`
+     * @param _sourceId Power source id
+     */
+    function enableSource(uint256 _sourceId)
+        external
+        sourceExists(_sourceId)
+        authP(MANAGE_POWER_SOURCE_ROLE, arr(uint256(1)))
+    {
+        PowerSource storage source = powerSources[_sourceId];
+        require(!_sourceEnabledAt(source, getBlockNumber()), ERROR_SOURCE_NOT_DISABLED);
+
+        source.activationHistory.push(
+            ActiveRange(
+                uint128(getBlockNumber64()), // enabled block
+                MAX_UINT128                  // disabled block
+            )
+        );
+
+        emit EnablePowerSource(_sourceId);
+    }
+
+    // ERC20 fns - note that this token is a non-transferrable "view-only" implementation.
+    // Users should only be changing balances by changing their balances in the underlying tokens.
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function approve(address, uint256) public returns (bool) {
+        return false;
+    }
+
+    function transfer(address, uint256) public returns (bool) {
+        return false;
+    }
+
+    function transferFrom(address, address, uint256) public returns (bool) {
+        return false;
+    }
+
+    function allowance(address, address) public view returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address _owner) public view returns (uint256) {
+        return balanceOfAt(_owner, getBlockNumber());
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return totalSupplyAt(getBlockNumber());
+    }
+
+    // Checkpointed fns
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function balanceOfAt(address _owner, uint256 _blockNumber) public view returns (uint256) {
+        return _aggregate(CallType.BalanceOfAt, abi.encode(_owner, _blockNumber));
+    }
+
+    function totalSupplyAt(uint256 _blockNumber) public view returns (uint256) {
+        return _aggregate(CallType.TotalSupplyAt, abi.encode(_blockNumber));
+    }
+
+    // Forwarding fns
+
+    /**
+    * @notice Tells whether the VotingAggregator app is a forwarder or not
+    * @dev IForwarder interface conformance
+    * @return Always true
+    */
+    function isForwarder() public pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @notice Execute desired action if you have voting power
+     * @dev IForwarder interface conformance
+     * @param _evmScript Script being executed
+     */
+    function forward(bytes _evmScript) public {
+        require(canForward(msg.sender, _evmScript), ERROR_CAN_NOT_FORWARD);
+        bytes memory input = new bytes(0);
+
+        // No blacklist needed as this contract should not hold any tokens from its sources
+        runScript(_evmScript, input, new address[](0));
+    }
+
+    /**
+    * @notice Tells whether `_sender` can forward actions or not
+    * @dev IForwarder interface conformance
+    * @param _sender Address of the account intending to forward an action
+    * @return True if the given address can forward actions, false otherwise
+    */
+    function canForward(address _sender, bytes) public view returns (bool) {
+        return hasInitialized() && balanceOf(_sender) > 0;
+    }
+
+    // Getter fns
+
+    /**
+     * @dev Return information about a power source
+     * @param _sourceId Power source id
+     * @return Power source address
+     * @return Power source type
+     * @return Power source weight
+     * @return Number of activation history points
+     */
+    function getPowerSource(uint256 _sourceId)
+        public
+        view
+        sourceExists(_sourceId)
+        returns (
+            address sourceAddress,
+            PowerSourceType sourceType,
+            uint256 weight,
+            uint256 historyLength
+        )
+    {
+        PowerSource storage source = powerSources[_sourceId];
+
+        sourceAddress = source.addr;
+        sourceType = source.sourceType;
+        weight = source.weight;
+        historyLength = source.activationHistory.length;
+    }
+
+    /**
+     * @dev Return information about a power source's activation history
+     * @param _sourceId Power source id
+     * @param _rangeIndex Index of activation history
+     * @return Start block of activation range
+     * @return End block of activation range
+     */
+    function getPowerSourceHistoryRange(uint256 _sourceId, uint256 _rangeIndex)
+        public
+        view
+        sourceExists(_sourceId)
+        returns (
+            uint128 enabledFromBlock,
+            uint128 disabledOnBlock
+        )
+    {
+        ActiveRange storage range = powerSources[_sourceId].activationHistory[_rangeIndex];
+
+        enabledFromBlock = range.enabledFromBlock;
+        disabledOnBlock = range.disabledOnBlock;
+    }
+
+    // Internal fns
+
+    function _aggregate(CallType _callType, bytes memory _paramdata) internal view returns (uint256) {
+        uint256 aggregate = 0;
+
+        for (uint256 i = 0; i < powerSourcesLength; i++) {
+            PowerSource storage source = powerSources[i];
+
+            bytes memory invokeData = abi.encodePacked(_selectorFor(_callType, source.sourceType), _paramdata);
+            (bool success, uint256 value) = source.addr.staticInvoke(invokeData);
+            require(success, ERROR_SOURCE_CALL_FAILED);
+
+            aggregate = aggregate.add(source.weight.mul(value));
+        }
+
+        return aggregate;
+    }
+
+    function _inActiveRange(ActiveRange storage _range, uint256 _blockNumber) internal view returns (bool) {
+        return _blockNumber >= _range.enabledFromBlock && _blockNumber < _range.disabledOnBlock;
+    }
+
+    function _sourceEnabledAt(PowerSource storage _source, uint256 _blockNumber) internal view returns (bool) {
+        ActiveRange[] storage history = _source.activationHistory;
+        uint256 historyLength = history.length;
+
+        // This should never happen, but we should return false anyhow
+        // Note that this also allows us to avoid using SafeMath later, as we've established there
+        // must be at least one history range
+        if (historyLength == 0) {
+            return false;
+        }
+
+        // Check last history range
+        uint256 lastHistoryIndex = historyLength - 1;
+        ActiveRange storage lastHistory = history[lastHistoryIndex];
+        if (_inActiveRange(lastHistory, _blockNumber)) {
+            return true;
+        } else if (historyLength == 1) {
+            // No need to go any further; we've checked the only history range
+            return false;
+        }
+
+        // Check first history range
+        ActiveRange storage firstHistory = history[0];
+        if (_inActiveRange(firstHistory, _blockNumber)) {
+            return true;
+        }
+
+        // Binary search through history
+        uint256 min = 0;
+        uint256 max = historyLength - 1;
+        while (max > min) {
+            uint256 mid = (max + min + 1) / 2;
+            ActiveRange storage midPoint = history[mid];
+            if (_inActiveRange(midPoint, _blockNumber)) {
+                // This range includes the given block number
+                return true;
+            }
+
+            if (_blockNumber >= midPoint.disabledOnBlock) {
+                min = mid;
+            } else if (_blockNumber < midPoint.enabledFromBlock) {
+                // Note that we don't need SafeMath here because mid must always be greater than 0
+                // from the while condition
+                max = mid - 1;
+            } else {
+                revert(ERROR_INVALID_SOURCE_ACTIVE_HISTORY);
+            }
+        }
+
+        // No ranges left to test
+        return false;
+    }
+
+    function _selectorFor(CallType _callType, PowerSourceType _sourceType) internal pure returns (bytes4) {
+        if (_sourceType == PowerSourceType.ERC20WithCheckpointing) {
+            if (_callType == CallType.BalanceOfAt) {
+                return IERC20WithCheckpointing(0).balanceOfAt.selector;
+            }
+            if (_callType == CallType.TotalSupplyAt) {
+                return IERC20WithCheckpointing(0).totalSupplyAt.selector;
+            }
+        }
+
+        if (_sourceType == PowerSourceType.ERC900) {
+            if (_callType == CallType.BalanceOfAt) {
+                return IERC900History(0).totalStakedForAt.selector;
+            }
+            if (_callType == CallType.TotalSupplyAt) {
+                return IERC900History(0).totalStakedAt.selector;
+            }
+        }
+
+        revert(ERROR_INVALID_CALL_OR_SELECTOR);
+    }
+
+    // Private fns
+
+}

--- a/contracts/examples/ExampleTemplate.sol
+++ b/contracts/examples/ExampleTemplate.sol
@@ -7,10 +7,10 @@ import "@aragon/os/contracts/lib/ens/PublicResolver.sol";
 import "@aragon/os/contracts/apm/APMNamehash.sol";
 
 import "@aragon/apps-voting/contracts/Voting.sol";
-import "@aragon/apps-shared-minime/contracts/MiniMeToken.sol";
 
 import "../test/mocks/ERC20Sample.sol";
 import "../TokenWrapper.sol";
+import "./IVotingGenericInitializer.sol";
 
 
 contract TemplateBase is APMNamehash {
@@ -42,13 +42,10 @@ contract TemplateBase is APMNamehash {
 
 
 contract ExampleTemplate is TemplateBase {
-    MiniMeTokenFactory tokenFactory;
-
     uint64 constant PCT = 10 ** 16;
     address constant ANY_ENTITY = address(-1);
 
     constructor(ENS ens) TemplateBase(DAOFactory(0), ens) public {
-        tokenFactory = new MiniMeTokenFactory();
     }
 
     function newInstance(ERC20 _wrappedToken) public {
@@ -57,22 +54,19 @@ contract ExampleTemplate is TemplateBase {
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
 
         address root = msg.sender;
-        bytes32 appId = keccak256(abi.encodePacked(apmNamehash("open"), keccak256("token-wrapper")));
+        bytes32 tokenWrapperAppId = keccak256(abi.encodePacked(apmNamehash("open"), keccak256("token-wrapper")));
         bytes32 votingAppId = apmNamehash("voting");
 
-        TokenWrapper app = TokenWrapper(dao.newAppInstance(appId, latestVersionAppBase(appId)));
+        TokenWrapper tokenWrapper = TokenWrapper(dao.newAppInstance(tokenWrapperAppId, latestVersionAppBase(tokenWrapperAppId)));
         Voting voting = Voting(dao.newAppInstance(votingAppId, latestVersionAppBase(votingAppId)));
 
-        MiniMeToken token = tokenFactory.createCloneToken(MiniMeToken(0), 0, "Org token", 18, "ORG", true);
-        token.changeController(app);
-
         // Initialize apps
-        app.initialize(token, _wrappedToken);
-        voting.initialize(token, 50 * PCT, 20 * PCT, 1 days);
+        tokenWrapper.initialize(_wrappedToken, "Org token", "ORG");
+        IVotingGenericInitializer(voting).initialize(tokenWrapper, 50 * PCT, 20 * PCT, 1 days);
 
         // HACK: create a random permission on TokenWrapper so it is detected as an app
         // Allow root to remove this permission if they'd like to uninstall this app in the future
-        acl.createPermission(address(-1), app, bytes32(-1), root);
+        acl.createPermission(address(-1), tokenWrapper, bytes32(-1), root);
 
         acl.createPermission(ANY_ENTITY, voting, voting.CREATE_VOTES_ROLE(), root);
 

--- a/contracts/examples/IVotingGenericInitializer.sol
+++ b/contracts/examples/IVotingGenericInitializer.sol
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+import "../IERC20WithCheckpointing.sol";
+
+
+contract IVotingGenericInitializer {
+    function initialize(IERC20WithCheckpointing _token, uint64 _supportRequiredPct, uint64 _minAcceptQuorumPct, uint64 _voteTime) external;
+}

--- a/contracts/test/mocks/ERC20Sample.sol
+++ b/contracts/test/mocks/ERC20Sample.sol
@@ -35,7 +35,7 @@ contract ERC20Sample is ERC20 {
         }
     }
 
-    function transferFrom(address _from, address _to, uint256 _amount) public returns (bool success){
+    function transferFrom(address _from, address _to, uint256 _amount) public returns (bool success) {
         /* solium-disable-next-line */
         if (balances[_from] >= _amount && allowed[_from][msg.sender] >= _amount && _amount > 0 && balances[_to] + _amount > balances[_to]) {
             balances[_from] -= _amount;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@aragon/cli": "^6.0.0",
-    "@aragon/minime": "^1.0.0",
     "@aragon/apps-shared-migrations": "1.0.0",
     "@aragon/apps-voting": "^2.0.0",
     "@aragon/test-helpers": "^1.0.0",

--- a/voting-aggregator-arapp.json
+++ b/voting-aggregator-arapp.json
@@ -1,0 +1,64 @@
+{
+  "environments": {
+    "default": {
+      "appName": "voting-aggregator.open.aragonpm.eth",
+      "network": "rpc"
+    },
+    "mainnet": {
+      "appName": "voting-aggregator.hatch.aragonpm.eth",
+      "network": "mainnet",
+      "registry": "0x314159265dd8dbb310642f98f50c066173c1259b",
+      "wsRPC": "wss://mainnet.eth.aragon.network/ws"
+    },
+    "rinkeby": {
+      "appName": "voting-aggregator.hatch.aragonpm.eth",
+      "network": "rinkeby",
+      "registry": "0x98Df287B6C145399Aaa709692c8D308357bC085D",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+    },
+    "rinkeby-open": {
+      "appName": "voting-aggregator.open.aragonpm.eth",
+      "network": "rinkeby",
+      "registry": "0x98Df287B6C145399Aaa709692c8D308357bC085D",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+    },
+    "ropsten": {
+      "appName": "voting-aggregator.open.aragonpm.eth",
+      "network": "ropsten",
+      "registry": "0x6afe2cacee211ea9179992f89dc61ff25c61e923",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+    },
+    "staging": {
+      "appName": "voting-aggregator.open.aragonpm.eth",
+      "network": "rinkeby",
+      "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
+      "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+    }
+  },
+  "roles": [
+    {
+      "name": "Add new power sources",
+      "id": "ADD_POWER_SOURCE_ROLE",
+      "params": [
+        "Source address",
+        "Source weight"
+      ]
+    },
+    {
+      "name": "Manage power sources",
+      "id": "MANAGE_POWER_SOURCE_ROLE ",
+      "params": [
+        "Enabling source"
+      ]
+    },
+    {
+      "name": "Manage power source weights",
+      "id": "MANAGE_WEIGHTS_ROLE",
+      "params": [
+        "New weight",
+        "Old weight"
+      ]
+    }
+  ],
+  "path": "contracts/VotingAggregator.sol"
+}


### PR DESCRIPTION
Adds an app to "sample" an NFT and convert it into a usable connector for the Voting app (or the Voting Aggregator).

The basic premise is that any account can register and "sample" any (and many) other accounts, at any time. Doing so checkpoints their current NFT balance at the time of sampling, allowing an imprecise but approximate measure for NFTs held by a particular address.

Note that it is especially important here to take into account runaway total supplies. If users were not re-sampled, total supply would continue growing over time as NFTs were transferred from one account to another.

It is conceivable that a user would want to re-sample all interested parties' actual NFT balances before creating a vote. This implementation currently also includes the concept of a sampling "epoch", whereby a privileged user can reset all sampled balances.

----------

We may also want to think of alternative permissioning schemes for sampling. With it being so open right now, it is conceivable someone could flood the voting power by registering known (or highly likely) parties that are uninterested.

One way of doing so is to protect the initial registration with a privilege, or only allow accounts to register for themselves or those that have given signed consent. Re-sampling could still be done at any time for already registered accounts (to combat total supply inflation double counting transferred NFTs).