### PR TITLE
ActivePeriod: polish

### DIFF
--- a/apps/voting-aggregator/contracts/VotingAggregator.sol
+++ b/apps/voting-aggregator/contracts/VotingAggregator.sol
@@ -111,7 +111,7 @@ contract VotingAggregator is IERC20WithCheckpointing, IForwarder, IsContract, ER
         source.weight = _weight;
 
         // Start activation history with [current block, max block)
-        source.activationHistory.startNewPeriodFrom(getBlockNumber());
+        source.activationHistory.startNextPeriodFrom(getBlockNumber());
 
         emit AddPowerSource(newSourceId, _sourceAddr, _sourceType, _weight);
 
@@ -165,7 +165,7 @@ contract VotingAggregator is IERC20WithCheckpointing, IForwarder, IsContract, ER
         PowerSource storage source = powerSources[_sourceId];
 
         // Add new activation period with [current block, max block)
-        source.activationHistory.startNewPeriodFrom(getBlockNumber());
+        source.activationHistory.startNextPeriodFrom(getBlockNumber());
 
         emit EnablePowerSource(_sourceId);
     }

--- a/shared/contract-utils/contracts/ActivePeriod.sol
+++ b/shared/contract-utils/contracts/ActivePeriod.sol
@@ -33,7 +33,7 @@ library ActivePeriod {
         Period[] history;
     }
 
-    function startNewPeriodFrom(History storage _self, uint256 _enabledFromTime) internal {
+    function startNextPeriodFrom(History storage _self, uint256 _enabledFromTime) internal {
         require(_enabledFromTime <= MAX_UINT128, ERROR_TIME_TOO_BIG);
 
         Period[] storage history = _self.history;

--- a/shared/contract-utils/contracts/ActivePeriod.sol
+++ b/shared/contract-utils/contracts/ActivePeriod.sol
@@ -14,10 +14,10 @@ pragma solidity ^0.4.24;
  *   - Staking (https://github.com/aragon/staking/blob/master/contracts/Checkpointing.sol)
  */
 library ActivePeriod {
-    uint256 private constant MAX_UINT128 = uint256(uint128(-1));
+    uint256 private constant MAX_UINT64 = uint256(uint64(-1));
 
     string private constant ERROR_TIME_TOO_BIG = "ACTIVEPERIOD_TIME_TOO_BIG";
-    string private constant ERROR_BAD_START_TIME = "ACTIVEPERIOD_BAD_START_TIME";
+    string private constant ERROR_LAST_PERIOD_ACTIVE = "ACTIVEPERIOD_LAST_PERIOD_ACTIVE";
     string private constant ERROR_NO_PERIODS = "ACTIVEPERIOD_NO_PERIODS";
     string private constant ERROR_LAST_NOT_ACTIVE = "ACTIVEPERIOD_LAST_NOT_ACTIVE";
     string private constant ERROR_BAD_STOP_TIME = "ACTIVEPERIOD_BAD_STOP_TIME";
@@ -25,8 +25,8 @@ library ActivePeriod {
 
     // Period of [enabledFromTime, disabledOnTime)
     struct Period {
-        uint128 enabledFromTime;
-        uint128 disabledOnTime;
+        uint64 enabledFromTime;
+        uint64 disabledOnTime;
     }
 
     struct History {
@@ -34,40 +34,43 @@ library ActivePeriod {
     }
 
     function startNextPeriodFrom(History storage _self, uint256 _enabledFromTime) internal {
-        require(_enabledFromTime <= MAX_UINT128, ERROR_TIME_TOO_BIG);
+        require(_enabledFromTime <= MAX_UINT64, ERROR_TIME_TOO_BIG);
 
         Period[] storage history = _self.history;
-        if (history.length > 0) {
+        uint256 historyLength = history.length;
+        if (historyLength > 0) {
             // Make sure there's no currently activated period
-            Period storage lastPeriod = history[history.length - 1];
-            require(lastPeriod.disabledOnTime <= _enabledFromTime, ERROR_BAD_START_TIME);
+            Period storage lastPeriod = history[historyLength - 1];
+            // Note that the disabledOnTime is not included in a period, so we include equality
+            require(uint256(lastPeriod.disabledOnTime) <= _enabledFromTime, ERROR_LAST_PERIOD_ACTIVE);
         }
 
         _self.history.push(
             Period({
-                enabledFromTime: uint128(_enabledFromTime),
-                disabledOnTime: uint128(MAX_UINT128)
+                enabledFromTime: uint64(_enabledFromTime),
+                disabledOnTime: uint64(MAX_UINT64)
             })
         );
     }
 
     function stopCurrentPeriodAt(History storage _self, uint256 _disabledOnTime) internal {
-        require(_disabledOnTime <= MAX_UINT128, ERROR_TIME_TOO_BIG);
-        uint128 castedStopTime = uint128(_disabledOnTime);
+        require(_disabledOnTime <= MAX_UINT64, ERROR_TIME_TOO_BIG);
 
         Period[] storage history = _self.history;
-        require(history.length > 0, ERROR_NO_PERIODS);
-        Period storage currentPeriod = history[history.length - 1];
+        uint256 historyLength = history.length;
+        require(historyLength > 0, ERROR_NO_PERIODS);
+        Period storage currentPeriod = history[historyLength - 1];
 
         // Make sure there is a currently activated period to stop
-        require(currentPeriod.disabledOnTime == MAX_UINT128, ERROR_LAST_NOT_ACTIVE);
-        require(currentPeriod.enabledFromTime < castedStopTime, ERROR_BAD_STOP_TIME);
+        require(uint256(currentPeriod.disabledOnTime) == MAX_UINT64, ERROR_LAST_NOT_ACTIVE);
+        // Note that the enabledFromTime is included in a period, so we disallow equality
+        require(uint256(currentPeriod.enabledFromTime) < _disabledOnTime, ERROR_BAD_STOP_TIME);
 
-        currentPeriod.disabledOnTime = castedStopTime;
+        currentPeriod.disabledOnTime = uint64(_disabledOnTime);
     }
 
     function isEnabledAt(History storage _self, uint256 _time) internal view returns (bool) {
-        require(_time <= MAX_UINT128, ERROR_TIME_TOO_BIG);
+        require(_time <= MAX_UINT64, ERROR_TIME_TOO_BIG);
 
         return _isEnabledAt(_self, _time);
     }
@@ -115,9 +118,9 @@ library ActivePeriod {
                 return true;
             }
 
-            if (_time >= midPoint.disabledOnTime) {
+            if (_time >= uint256(midPoint.disabledOnTime)) {
                 low = mid;
-            } else if (_time < midPoint.enabledFromTime) {
+            } else if (_time < uint256(midPoint.enabledFromTime)) {
                 // Note that we don't need SafeMath here because mid must always be greater than 0
                 // from the while condition
                 high = mid - 1;
@@ -131,6 +134,7 @@ library ActivePeriod {
     }
 
     function _inActivePeriod(Period storage _period, uint256 _time) private view returns (bool) {
-        return _time >= _period.enabledFromTime && _time < _period.disabledOnTime;
+        // [enabledFromTime, disabledOnTime)
+        return uint256(_period.enabledFromTime) <= _time && _time < uint256(_period.disabledOnTime);
     }
 }

--- a/shared/contract-utils/contracts/test/mocks/ActivePeriodWrapper.sol
+++ b/shared/contract-utils/contracts/test/mocks/ActivePeriodWrapper.sol
@@ -6,10 +6,10 @@ import "../../ActivePeriod.sol";
 contract ActivePeriodWrapper {
     using ActivePeriod for ActivePeriod.History;
 
-    ActivePeriod.History activationHistory;
+    ActivePeriod.History internal activationHistory;
 
-    function startNewPeriodFrom(uint256 _enabledFromTime) external {
-        activationHistory.startNewPeriodFrom(_enabledFromTime);
+    function startNextPeriodFrom(uint256 _enabledFromTime) external {
+        activationHistory.startNextPeriodFrom(_enabledFromTime);
     }
 
     function stopCurrentPeriodAt(uint256 _disabledOnTime) external {

--- a/shared/contract-utils/contracts/test/mocks/ActivePeriodWrapper.sol
+++ b/shared/contract-utils/contracts/test/mocks/ActivePeriodWrapper.sol
@@ -20,7 +20,7 @@ contract ActivePeriodWrapper {
         return activationHistory.isEnabledAt(_time);
     }
 
-    function getPeriod(uint256 _index) external view returns (uint128 enabledFromTime,  uint128 disabledOnTime) {
+    function getPeriod(uint256 _index) external view returns (uint64 enabledFromTime,  uint64 disabledOnTime) {
         ActivePeriod.Period memory period = activationHistory.getPeriod(_index);
         return (period.enabledFromTime, period.disabledOnTime);
     }

--- a/shared/contract-utils/test/active_period.js
+++ b/shared/contract-utils/test/active_period.js
@@ -3,13 +3,13 @@ const { assertRevert } = require('@aragon/test-helpers/assertThrow')
 const ActivePeriodWrapper = artifacts.require('ActivePeriodWrapper')
 
 const ERROR_TIME_TOO_BIG = 'ACTIVEPERIOD_TIME_TOO_BIG'
-const ERROR_BAD_START_TIME = 'ACTIVEPERIOD_BAD_START_TIME'
+const ERROR_LAST_PERIOD_ACTIVE = 'ACTIVEPERIOD_LAST_PERIOD_ACTIVE'
 const ERROR_NO_PERIODS = 'ACTIVEPERIOD_NO_PERIODS'
 const ERROR_LAST_NOT_ACTIVE = 'ACTIVEPERIOD_LAST_NOT_ACTIVE'
 const ERROR_BAD_STOP_TIME = 'ACTIVEPERIOD_BAD_STOP_TIME'
 const ERROR_INVALID_SEARCH = 'ACTIVEPERIOD_INVALID_SEARCH'
 
-const MAX_UINT128 = new web3.BigNumber(2).pow(128).sub(new web3.BigNumber(1))
+const MAX_UINT64 = new web3.BigNumber(2).pow(64).sub(new web3.BigNumber(1))
 
 contract('ActivePeriod lib', ([_, root]) => {
   let activePeriodWrapper
@@ -31,7 +31,7 @@ contract('ActivePeriod lib', ([_, root]) => {
     })
 
     it('fails to start a new period if period is too big', async () => {
-      const enabledFromTime = MAX_UINT128.add(new web3.BigNumber(1))
+      const enabledFromTime = MAX_UINT64.add(new web3.BigNumber(1))
       await assertRevert(activePeriodWrapper.startNextPeriodFrom(enabledFromTime), ERROR_TIME_TOO_BIG)
     })
 
@@ -40,7 +40,7 @@ contract('ActivePeriod lib', ([_, root]) => {
       await activePeriodWrapper.startNextPeriodFrom(firstEnabledFromTime)
 
       const enabledFromTime = 1
-      await assertRevert(activePeriodWrapper.startNextPeriodFrom(enabledFromTime), ERROR_BAD_START_TIME)
+      await assertRevert(activePeriodWrapper.startNextPeriodFrom(enabledFromTime), ERROR_LAST_PERIOD_ACTIVE)
     })
   })
   describe('stop current period', () => {
@@ -82,7 +82,7 @@ contract('ActivePeriod lib', ([_, root]) => {
         })
 
         it('fails to stop current period if period is too big', async () => {
-          const disabledOnTime = MAX_UINT128.add(new web3.BigNumber(1))
+          const disabledOnTime = MAX_UINT64.add(new web3.BigNumber(1))
           await assertRevert(activePeriodWrapper.stopCurrentPeriodAt(disabledOnTime), ERROR_TIME_TOO_BIG)
         })
 

--- a/shared/contract-utils/test/active_period.js
+++ b/shared/contract-utils/test/active_period.js
@@ -24,7 +24,7 @@ contract('ActivePeriod lib', ([_, root]) => {
 
       assert.isFalse(await activePeriodWrapper.isEnabledAt(enabledFromTime))
 
-      await activePeriodWrapper.startNewPeriodFrom(enabledFromTime)
+      await activePeriodWrapper.startNextPeriodFrom(enabledFromTime)
 
       assert.isFalse(await activePeriodWrapper.isEnabledAt(enabledFromTime - 1))
       assert.isTrue(await activePeriodWrapper.isEnabledAt(enabledFromTime))
@@ -32,15 +32,15 @@ contract('ActivePeriod lib', ([_, root]) => {
 
     it('fails to start a new period if period is too big', async () => {
       const enabledFromTime = MAX_UINT128.add(new web3.BigNumber(1))
-      await assertRevert(activePeriodWrapper.startNewPeriodFrom(enabledFromTime), ERROR_TIME_TOO_BIG)
+      await assertRevert(activePeriodWrapper.startNextPeriodFrom(enabledFromTime), ERROR_TIME_TOO_BIG)
     })
 
     it('fails to start a new period if there is a previous activated one', async () => {
       const firstEnabledFromTime = 0
-      await activePeriodWrapper.startNewPeriodFrom(firstEnabledFromTime)
+      await activePeriodWrapper.startNextPeriodFrom(firstEnabledFromTime)
 
       const enabledFromTime = 1
-      await assertRevert(activePeriodWrapper.startNewPeriodFrom(enabledFromTime), ERROR_BAD_START_TIME)
+      await assertRevert(activePeriodWrapper.startNextPeriodFrom(enabledFromTime), ERROR_BAD_START_TIME)
     })
   })
   describe('stop current period', () => {
@@ -54,7 +54,7 @@ contract('ActivePeriod lib', ([_, root]) => {
     context('when there is a period', () => {
       const enabledFromTime = 10
       beforeEach('start new period', async () => {
-        await activePeriodWrapper.startNewPeriodFrom(enabledFromTime)
+        await activePeriodWrapper.startNextPeriodFrom(enabledFromTime)
       })
 
       context('when the last period is not active', () => {

--- a/shared/contract-utils/test/helpers/math.js
+++ b/shared/contract-utils/test/helpers/math.js
@@ -1,0 +1,11 @@
+// See https://stackoverflow.com/a/1527820
+// Modified to not be inclusive at the end range
+function getRandomInt(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+module.exports = {
+  getRandomInt,
+}


### PR DESCRIPTION
- Uses `uint64` for time units, to align with `Checkpoint`
- Optimizes some of the SLOADs
- Clarifies with more comments / cosmetic code changes
- Polishes tests