### PR TITLE
chore: upgrade aragonCLI to v7

### DIFF
--- a/apps/token-wrapper/contracts/examples/ExampleTemplate.sol
+++ b/apps/token-wrapper/contracts/examples/ExampleTemplate.sol
@@ -16,7 +16,8 @@ contract TemplateBase is APMNamehash {
     ENS public ens;
     DAOFactory public fac;
 
-    event DeployInstance(address dao);
+    event DeployDao(address dao);
+    event SetupDao(address dao);
     event InstalledApp(address appProxy, bytes32 appId);
 
     constructor(DAOFactory _fac, ENS _ens) public {
@@ -49,6 +50,8 @@ contract ExampleTemplate is TemplateBase {
 
     function newInstance(ERC20 _depositedToken) public {
         Kernel dao = fac.newDAO(this);
+        emit SetupDao(dao);
+
         ACL acl = ACL(dao.acl());
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
 
@@ -78,6 +81,6 @@ contract ExampleTemplate is TemplateBase {
         acl.revokePermission(this, acl, acl.CREATE_PERMISSIONS_ROLE());
         acl.setPermissionManager(root, acl, acl.CREATE_PERMISSIONS_ROLE());
 
-        emit DeployInstance(dao);
+        emit SetupDao(dao);
     }
 }

--- a/apps/token-wrapper/contracts/examples/ExampleTemplate.sol
+++ b/apps/token-wrapper/contracts/examples/ExampleTemplate.sol
@@ -50,7 +50,7 @@ contract ExampleTemplate is TemplateBase {
 
     function newInstance(ERC20 _depositedToken) public {
         Kernel dao = fac.newDAO(this);
-        emit SetupDao(dao);
+        emit DeployDao(dao);
 
         ACL acl = ACL(dao.acl());
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);

--- a/apps/token-wrapper/package.json
+++ b/apps/token-wrapper/package.json
@@ -36,7 +36,7 @@
     "@aragon/apps-shared-migrations": "^1.0.0",
     "@aragon/apps-shared-minime": "^1.0.0",
     "@aragon/apps-voting": "^2.0.0",
-    "@aragon/cli": "^6.4.4",
+    "@aragon/cli": "^7.0.0",
     "@aragon/test-helpers": "^2.1.0",
     "@aragon/truffle-config-v4": "^1.0.0",
     "ethereumjs-abi": "^0.6.4",

--- a/apps/voting-aggregator/package.json
+++ b/apps/voting-aggregator/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@aragon/apps-shared-migrations": "^1.0.0",
-    "@aragon/cli": "^6.4.4",
+    "@aragon/cli": "^7.0.0",
     "@aragon/test-helpers": "^2.1.0",
     "@aragon/truffle-config-v4": "^1.0.0",
     "ethereumjs-abi": "^0.6.4",


### PR DESCRIPTION
Errors still present:

- [x] `aragon run` complains that it can't find the `DeployDao` event from my template, even though my template now should be using the correct event signature
- [ ] aragonCLI still requires `truffle@5`