### PR TITLE
Migrate to new ENS registry

### DIFF
--- a/apps/token-wrapper/arapp.json
+++ b/apps/token-wrapper/arapp.json
@@ -7,7 +7,7 @@
     "mainnet": {
       "appName": "token-wrapper.hatch.aragonpm.eth",
       "network": "mainnet",
-      "registry": "0x314159265dd8dbb310642f98f50c066173c1259b",
+      "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
       "wsRPC": "wss://mainnet.eth.aragon.network/ws"
     },
     "rinkeby": {

--- a/apps/voting-aggregator/arapp.json
+++ b/apps/voting-aggregator/arapp.json
@@ -7,7 +7,7 @@
     "mainnet": {
       "appName": "voting-aggregator.hatch.aragonpm.eth",
       "network": "mainnet",
-      "registry": "0x314159265dd8dbb310642f98f50c066173c1259b",
+      "registry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
       "wsRPC": "wss://mainnet.eth.aragon.network/ws"
     },
     "rinkeby": {


### PR DESCRIPTION
See [migration details](https://medium.com/the-ethereum-name-service/ens-registry-migration-bug-fix-new-features-64379193a5a).