### PR TITLE
Token Wrapper: add installation guide

### DIFF
--- a/apps/token-wrapper/readme.md
+++ b/apps/token-wrapper/readme.md
@@ -14,41 +14,47 @@ In efforts to save gas costs and space to introduce the checkpointing, token amo
 
 ## How to install
 
-**Prerequisites:** [aragonCLI](https://hack.aragon.org/docs/cli-intro) is needed to install the TokenWrapper to a DAO. Also note that you may have to change `--env aragon:rinkeby`  for  `--env aragon:mainnet` in case the organization is on mainnet.
+**Prerequisites:** [aragonCLI](https://hack.aragon.org/docs/cli-intro) is needed to install the Token Wrapper to a DAO. Also note that you may have to change `--env aragon:rinkeby` for `--env aragon:mainnet` in case the organization is on mainnet.
 
-
-### 1. The first step is to install the app to your DAO: 
+### 1. The first step is to install the app into your DAO: 
 
 ```
-dao install <DAO address> token-wrapper.hatch.aragonpm.eth --app-init-args <Token address> <Wrapped token name> <Wrapped token symbol> --env aragon:rinkeby
+dao install <DAO address> token-wrapper.hatch.aragonpm.eth --app-init-args <token address> <wrapped token name> <wrapped token symbol> --env aragon:rinkeby
 ```
 
-This will install the new app that acts as a [Minime token](https://github.com/Giveth/minime).
+The `token address` is the address of the ERC20 token you would like users to "wrap" into an organizational [MiniMe token](https://github.com/aragon/minime).
 
+You can verify that the Token Wrapper app was installed into your org with:
+
+```sh
+dao apps <DAO address> --all --env aragon:rinkeby
 
 ### 2. Next, create a permission for the TokenWrapper:
 
 ```
-dao acl create <DAO address> <token-wrapper address> ROLE <Voting app address> <Voting app address> --env aragon:rinkeby
-``` 
-You can get the token-wrapper address by listing the apps of your DAO with the following command: 
-```
+dao acl create <DAO address> <Token Wrapper app address> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff <Voting app address> <Voting app address> --env aragon:rinkeby
 dao apps <DAO address> --all --env aragon:rinkeby
 ```
-At this point, you should be able to view the TokenWrapper app in the frontend. You can try it out by wrapping one of your tokens.
 
-### 3. Then, create a new Voting app instance linked to your wrapped tokens:
+At this point, you should be able to view the Token Wrapper app in the frontend. You can try it out by wrapping one of your tokens.
+
+
+### 3. Then, create a new Voting app instance powered by your Token Wrapper:
+
 ```
-dao install <DAO address> voting --app-init-args <token-wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
+dao install <DAO address> voting --app-init-args <Token Wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
 ```
-The voting parameters in the command are:
+
+The command above includes the following voting parameters:
 
 - `500000000000000000`: 50% minimum support
 - `150000000000000000`: 15% minimum approval
 - `604800`: Voting period of 7 days (604800 seconds)
 
 ### 4. And finally, create a permission for the new Voting app instance:
+
 ```
-dao acl create <DAO address> <new Voting app address> CREATE_VOTES_ROLE <token-wrapper address> <new Voting app address> --env aragon:rinkeby
+dao acl create <DAO address> <new Voting app address> CREATE_VOTES_ROLE <Token Wrapper address> <new Voting app address> --env aragon:rinkeby
 ```
-This will let anyone who has wrapped at least one of their existing token to create a new vote.
+
+This will let anyone who has wrapped at least one of their existing token to create a new vote (as well as vote in any open votes).

--- a/apps/token-wrapper/readme.md
+++ b/apps/token-wrapper/readme.md
@@ -23,27 +23,32 @@ In efforts to save gas costs and space to introduce the checkpointing, token amo
 dao install <DAO address> token-wrapper.hatch.aragonpm.eth --app-init-args <Token address> <Wrapped token name> <Wrapped token symbol> --env aragon:rinkeby
 ```
 
-This will install the new app that acts as a Minime token.
+This will install the new app that acts as a [Minime token](https://github.com/Giveth/minime).
 
 
 ### 2. Next, create a permission for the TokenWrapper:
 
 ```
-dao acl create <dao address> <token-wrapper address> ROLE <voting app address> <voting app address> --env aragon:rinkeby
+dao acl create <DAO address> <token-wrapper address> ROLE <voting app address> <voting app address> --env aragon:rinkeby
 ``` 
 You can get the token-wrapper address by listing the apps of your DAO with the following command: 
 ```
-dao apps <dao address> --all --env aragon:rinkeby
+dao apps <DAO address> --all --env aragon:rinkeby
 ```
 At this point, you should be able to view the TokenWrapper app in the frontend. You can try it out by wrapping one of your tokens.
 
 ### 3. Then, create a new voting app instance linked to your wrapped tokens:
 ```
-dao install <dao address> voting --app-init-args <token-wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
+dao install <DAO address> voting --app-init-args <token-wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
 ```
+The voting parameters in the command are:
+
+- `500000000000000000`: 50% minimum support
+- `150000000000000000`: 15% minimum approval
+- `604800`: Voting period of 7 days (604800 seconds)
 
 ### 4. And finally, create a permission for the new Voting app instance:
 ```
-dao acl create <dao address> <new voting app address> CREATE_VOTES_ROLE <token-wrapper address> <new voting app address> --env aragon:rinkeby
+dao acl create <DAO address> <new voting app address> CREATE_VOTES_ROLE <token-wrapper address> <new voting app address> --env aragon:rinkeby
 ```
-This will basically let anyone who has wrapped one of their existing ERC-20 token to create a new vote.
+This will let anyone who has wrapped at least one of their existing token to create a new vote.

--- a/apps/token-wrapper/readme.md
+++ b/apps/token-wrapper/readme.md
@@ -11,3 +11,39 @@ The `TokenWrapper` contract has not yet been professionally audited. It is relat
 ## Caveats
 
 In efforts to save gas costs and space to introduce the checkpointing, token amounts are limited to `uint192`. This should not pose a problem for any token, but as `uint192` supports a _very_ large range of numbers, but the TokenWrapper will stop accepting deposits once if it hits `2^192 - 1`.
+
+## How to install
+
+**Prerequisites:** [aragonCLI](https://hack.aragon.org/docs/cli-intro) is needed to install the TokenWrapper to a DAO. Also note that you may have to change `--env aragon:rinkeby`  for  `--env aragon:mainnet` in case the organization is on mainnet.
+
+
+### 1. The first step is to install the app to your DAO: 
+
+```
+dao install <DAO address> token-wrapper.hatch.aragonpm.eth --app-init-args <Token address> <Wrapped token name> <Wrapped token symbol> --env aragon:rinkeby
+```
+
+This will install the new app that acts as a Minime token.
+
+
+### 2. Next, create a permission for the TokenWrapper:
+
+```
+dao acl create <dao address> <token-wrapper address> ROLE <voting app address> <voting app address> --env aragon:rinkeby
+``` 
+You can get the token-wrapper address by listing the apps of your DAO with the following command: 
+```
+dao apps <dao address> --all --env aragon:rinkeby
+```
+At this point, you should be able to view the TokenWrapper app in the frontend. You can try it out by wrapping one of your tokens.
+
+### 3. Then, create a new voting app instance linked to your wrapped tokens:
+```
+dao install <dao address> voting --app-init-args <token-wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
+```
+
+### 4. And finally, create a permission for the new Voting app instance:
+```
+dao acl create <dao address> <new voting app address> CREATE_VOTES_ROLE <token-wrapper address> <new voting app address> --env aragon:rinkeby
+```
+This will basically let anyone who has wrapped one of their existing ERC-20 token to create a new vote.

--- a/apps/token-wrapper/readme.md
+++ b/apps/token-wrapper/readme.md
@@ -12,11 +12,11 @@ The `TokenWrapper` contract has not yet been professionally audited. It is relat
 
 In efforts to save gas costs and space to introduce the checkpointing, token amounts are limited to `uint192`. This should not pose a problem for any token, but as `uint192` supports a _very_ large range of numbers, but the TokenWrapper will stop accepting deposits once if it hits `2^192 - 1`.
 
-## How to install
+## Installation Tutorial
 
-**Prerequisites:** [aragonCLI](https://hack.aragon.org/docs/cli-intro) is needed to install the Token Wrapper to a DAO. Also note that you may have to change `--env aragon:rinkeby` for `--env aragon:mainnet` in case the organization is on mainnet.
+**Prerequisites:** [aragonCLI](https://hack.aragon.org/docs/cli-intro) is needed to install the Token Wrapper into a DAO. Also note that you may have to change `--env aragon:rinkeby` for `--env aragon:mainnet` if the organization is on mainnet.
 
-### 1. The first step is to install the app into your DAO: 
+### 1. The first step is to install the Token Wrapper into your DAO:
 
 ```
 dao install <DAO address> token-wrapper.hatch.aragonpm.eth --app-init-args <token address> <wrapped token name> <wrapped token symbol> --env aragon:rinkeby
@@ -24,19 +24,25 @@ dao install <DAO address> token-wrapper.hatch.aragonpm.eth --app-init-args <toke
 
 The `token address` is the address of the ERC20 token you would like users to "wrap" into an organizational [MiniMe token](https://github.com/aragon/minime).
 
-You can verify that the Token Wrapper app was installed into your org with:
+You can verify that the Token Wrapper app was installed into your organization with:
 
 ```sh
 dao apps <DAO address> --all --env aragon:rinkeby
+```
 
 ### 2. Next, create a permission for the TokenWrapper:
 
-```
+```sh
 dao acl create <DAO address> <Token Wrapper app address> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff <Voting app address> <Voting app address> --env aragon:rinkeby
+```
+
+You can get the installed Token Wrapper's address by listing the apps of your DAO with the following command:
+
+```sh
 dao apps <DAO address> --all --env aragon:rinkeby
 ```
 
-At this point, you should be able to view the Token Wrapper app in the frontend. You can try it out by wrapping one of your tokens.
+At this point, you should be able to view the Token Wrapper app in the Aragon client. You can try it out by wrapping one of your tokens.
 
 
 ### 3. Then, create a new Voting app instance powered by your Token Wrapper:
@@ -45,7 +51,7 @@ At this point, you should be able to view the Token Wrapper app in the frontend.
 dao install <DAO address> voting --app-init-args <Token Wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
 ```
 
-The command above includes the following voting parameters:
+The command above uses the following voting parameters:
 
 - `500000000000000000`: 50% minimum support
 - `150000000000000000`: 15% minimum approval
@@ -57,4 +63,4 @@ The command above includes the following voting parameters:
 dao acl create <DAO address> <new Voting app address> CREATE_VOTES_ROLE <Token Wrapper address> <new Voting app address> --env aragon:rinkeby
 ```
 
-This will let anyone who has wrapped at least one of their existing token to create a new vote (as well as vote in any open votes).
+This will let anyone who has wrapped at least one of their existing token to create a new vote, as well as vote in any open votes.

--- a/apps/token-wrapper/readme.md
+++ b/apps/token-wrapper/readme.md
@@ -29,7 +29,7 @@ This will install the new app that acts as a [Minime token](https://github.com/G
 ### 2. Next, create a permission for the TokenWrapper:
 
 ```
-dao acl create <DAO address> <token-wrapper address> ROLE <voting app address> <voting app address> --env aragon:rinkeby
+dao acl create <DAO address> <token-wrapper address> ROLE <Voting app address> <Voting app address> --env aragon:rinkeby
 ``` 
 You can get the token-wrapper address by listing the apps of your DAO with the following command: 
 ```
@@ -37,7 +37,7 @@ dao apps <DAO address> --all --env aragon:rinkeby
 ```
 At this point, you should be able to view the TokenWrapper app in the frontend. You can try it out by wrapping one of your tokens.
 
-### 3. Then, create a new voting app instance linked to your wrapped tokens:
+### 3. Then, create a new Voting app instance linked to your wrapped tokens:
 ```
 dao install <DAO address> voting --app-init-args <token-wrapper address> 500000000000000000 150000000000000000 604800 --env aragon:rinkeby
 ```
@@ -49,6 +49,6 @@ The voting parameters in the command are:
 
 ### 4. And finally, create a permission for the new Voting app instance:
 ```
-dao acl create <DAO address> <new voting app address> CREATE_VOTES_ROLE <token-wrapper address> <new voting app address> --env aragon:rinkeby
+dao acl create <DAO address> <new Voting app address> CREATE_VOTES_ROLE <token-wrapper address> <new Voting app address> --env aragon:rinkeby
 ```
 This will let anyone who has wrapped at least one of their existing token to create a new vote.


### PR DESCRIPTION
Adds a small guide on how to install the Token Wrapper to an organization.